### PR TITLE
Improved output and error handling

### DIFF
--- a/lib/vagrant-windows-domain/action/leave_domain.rb
+++ b/lib/vagrant-windows-domain/action/leave_domain.rb
@@ -24,33 +24,32 @@ module VagrantPlugins
 
       def call(env)
 
-        if [:not_created].include? @machine.state.id
-          @logger.debug("Machine not created, nothing to do")
-        elsif [:running].include? @machine.state.id
-          answer = @machine.env.ui.ask("Are you sure you want to destroy this machine and disconnect from #{@config.domain}? (y/n)")
-          if answer.downcase == 'y'
-            env[:force_confirm_destroy] = true # Prevent the popup dialog again
+        if @config and @config.include? "domain"
 
-            # OK, you want to kill. But do we have a valid config?
-            if @config
-              @logger.debug("Configuration detected, triggering leave domain action")
-              @provisioner.destroy
-            else
-              @logger.debug("No configuration detected, not leaving any domain")
-            end
+       	  if [:not_created].include? @machine.state.id
+       	    @logger.debug("Machine not created, nothing to do")
+       	  elsif [:running].include? @machine.state.id
+       	    answer = @machine.env.ui.ask("Are you sure you want to destroy this machine and disconnect from #{@config.domain}? (y/n)")
+       	    if answer.downcase == 'y'
+       	    	env[:force_confirm_destroy] = true # Prevent the popup dialog again
+       	    	@logger.debug("Valid configuration detected, triggering leave domain action")
+       	    	@provisioner.destroy
+       	    end
+       	  # elsif [:saved, :paused, :poweroff].include? @machine.state.id
+       	  else
+       	    @machine.env.ui.say(:warn, "Machine is currently not running. To properly leave the #{@config.domain} network the machine needs to be running and connected to the network in which it was provisioned. Please run `vagrant up` and then `vagrant destroy`.\n")
+       	    answer = @machine.env.ui.ask("Would you like to continue destroying this machine, leaving this machine orphaned in the '#{@config.domain}' network? (y/n)")
+       	    return unless answer.downcase == 'y' # Bail out of destroy and prevent middleware from continuing on
 
-          end
-        # elsif [:saved, :paused, :poweroff].include? @machine.state.id
-        else
-          @machine.env.ui.say(:warn, "Machine is currently not running. To properly leave the #{@config.domain} network the machine needs to be running and connected to the network in which it was provisioned. Please run `vagrant up` and then `vagrant destroy`.\n")
-          answer = @machine.env.ui.ask("Would you like to continue destroying this machine, leaving this machine orphaned in the '#{@config.domain}' network? (y/n)")
-          return unless answer.downcase == 'y' # Bail out of destroy and prevent middleware from continuing on
+       	    # OK, we're being naughty and letting the rest of the middleware do their things (i.e. destroy the machine, and such)
 
-          env[:force_confirm_destroy] = true # Prevent the popup dialog again
-
-          @logger.debug("Force destroying this machine and not leaving the domain #{@config.domain}")
-          @machine.env.ui.say(:warn, "Force destroying this machine and not leaving the domain #{@config.domain}. May FSM have mercy on your soul.")
-        end
+       	    env[:force_confirm_destroy] = true # Prevent the popup dialog again
+       	    @logger.debug("Force destroying this machine and not leaving the domain #{@config.domain}")
+       	    @machine.env.ui.say(:warn, "Force destroying this machine and not leaving the domain #{@config.domain}. May FSM have mercy on your soul.")
+       	  end
+       	else
+       	  @logger.debug("No configuration detected, not leaving any domain")
+       	end
 
         # Continue the rest of the middleware actions
         @app.call(env)

--- a/lib/vagrant-windows-domain/action/leave_domain.rb
+++ b/lib/vagrant-windows-domain/action/leave_domain.rb
@@ -23,11 +23,10 @@ module VagrantPlugins
         if @config
           @logger.debug("Configuration detected, triggering leave domain action")
           @provisioner.destroy
-          @app.call(env)
         else
           @logger.debug("No configuration detected, not leaving any domain")
-          @app.call(env)
         end
+        @app.call(env)
       end
 
     end

--- a/lib/vagrant-windows-domain/action/leave_domain.rb
+++ b/lib/vagrant-windows-domain/action/leave_domain.rb
@@ -1,5 +1,4 @@
 require_relative '../provisioner'
-require 'pp'
 
 module VagrantPlugins
   module WindowsDomain
@@ -24,8 +23,6 @@ module VagrantPlugins
       end
 
       def call(env)
-        require 'pp'
-        pp @machine.state
 
         if [:not_created].include? @machine.state.id
           @logger.debug("Machine not created, nothing to do")

--- a/lib/vagrant-windows-domain/action/leave_domain.rb
+++ b/lib/vagrant-windows-domain/action/leave_domain.rb
@@ -3,6 +3,9 @@ require 'pp'
 
 module VagrantPlugins
   module WindowsDomain
+    # Include the built-in modules so we can use them as top-level things.
+    include Vagrant::Action::Builtin
+
     class LeaveDomain
       include VagrantPlugins::WindowsDomain
 
@@ -10,6 +13,7 @@ module VagrantPlugins
         @logger = Log4r::Logger.new("vagrant::provisioners::vagrant_windows_domain")
         @logger.debug("Initialising WindowsDomain plugin on destroy action")
         @app = app
+        @env = env
         @machine = env[:machine]
 
         @machine.config.vm.provisioners.each do |prov|
@@ -20,12 +24,38 @@ module VagrantPlugins
       end
 
       def call(env)
-        if @config
-          @logger.debug("Configuration detected, triggering leave domain action")
-          @provisioner.destroy
+        require 'pp'
+        pp @machine.state
+
+        if [:not_created].include? @machine.state.id
+          @logger.debug("Machine not created, nothing to do")
+        elsif [:running].include? @machine.state.id
+          answer = @machine.env.ui.ask("Are you sure you want to destroy this machine and disconnect from #{@config.domain}? (y/n)")
+          if answer.downcase == 'y'
+            env[:force_confirm_destroy] = true # Prevent the popup dialog again
+
+            # OK, you want to kill. But do we have a valid config?
+            if @config
+              @logger.debug("Configuration detected, triggering leave domain action")
+              @provisioner.destroy
+            else
+              @logger.debug("No configuration detected, not leaving any domain")
+            end
+
+          end
+        # elsif [:saved, :paused, :poweroff].include? @machine.state.id
         else
-          @logger.debug("No configuration detected, not leaving any domain")
+          @machine.env.ui.say(:warn, "Machine is currently not running. To properly leave the #{@config.domain} network the machine needs to be running and connected to the network in which it was provisioned. Please run `vagrant up` and then `vagrant destroy`.\n")
+          answer = @machine.env.ui.ask("Would you like to continue destroying this machine, leaving this machine orphaned in the '#{@config.domain}' network? (y/n)")
+          return unless answer.downcase == 'y' # Bail out of destroy and prevent middleware from continuing on
+
+          env[:force_confirm_destroy] = true # Prevent the popup dialog again
+
+          @logger.debug("Force destroying this machine and not leaving the domain #{@config.domain}")
+          @machine.env.ui.say(:warn, "Force destroying this machine and not leaving the domain #{@config.domain}. May FSM have mercy on your soul.")
         end
+
+        # Continue the rest of the middleware actions
         @app.call(env)
       end
 

--- a/lib/vagrant-windows-domain/action/leave_domain.rb
+++ b/lib/vagrant-windows-domain/action/leave_domain.rb
@@ -8,6 +8,11 @@ module VagrantPlugins
     class LeaveDomain
       include VagrantPlugins::WindowsDomain
 
+      attr_accessor :machine
+      attr_accessor :config
+      attr_accessor :env
+      attr_accessor :app
+
       def initialize(app, env)
         @logger = Log4r::Logger.new("vagrant::provisioners::vagrant_windows_domain")
         @logger.debug("Initialising WindowsDomain plugin on destroy action")

--- a/spec/provisioner/leave_domain_spec.rb
+++ b/spec/provisioner/leave_domain_spec.rb
@@ -10,7 +10,8 @@ describe VagrantPlugins::WindowsDomain::LeaveDomain do
   let(:instance) { described_class.new }
 
   let(:root_path)           { (Pathname.new(Dir.mktmpdir)).to_s }
-  let(:ui)                  { Vagrant::UI::Silent.new }
+  let(:domain)				{ "foo.com" }
+  let(:ui)                  { double("ui") }
   let(:app)                 { double("app") }
   let(:communicator)        { double ("communicator") }
   let(:shell)               { double ("shell") }
@@ -23,41 +24,87 @@ describe VagrantPlugins::WindowsDomain::LeaveDomain do
   let(:root_config)        	{ double("root_config", vm: vm) } 
   let(:env)                 { {:ui => ui, :machine => machine} }
   let(:machine)             { double("machine", ui: ui, id: "1234", config: root_config) }
+  let(:provisioner)         { double("provisioner") }
   subject                   { described_class.new app, env }
 
   describe "call" do
 
     before do
-      env = double("environment", root_path: "/tmp/vagrant-windows-domain-path", machine: machine)
       allow(machine).to receive(:communicate).and_return(communicator)
       allow(env).to receive(:machine).and_return(machine)
       allow(communicator).to receive(:shell).and_return(shell)
       allow(shell).to receive(:powershell).and_yield(:stdout, "myoldcomputername")
+	  config.domain = domain
+      allow(env).to receive(:machine).and_return(machine)
+      allow(machine).to receive(:env).and_return(env)
+      allow(env).to receive(:ui).and_return(ui)
+      subject.provisioner = provisioner
     end
 
     context "when no configuration exists for the machine" do
 		it "should pass control to the next middleware Action" do
-
+			config.domain = nil
+			expect(app).to receive(:call).with(env)
+			subject.call(env)
 		end
     end
 
   	context "when machine is running" do
 		it "should prompt the user if they would like to destroy & d/c the machine" do
+			state = double("state", id: :running)
+			expect(provisioner).to receive(:destroy)
+
+			expect(app).to receive(:call).with(env)
+      		expect(ui).to receive(:ask).with("Are you sure you want to destroy this machine and disconnect from #{domain}? (y/n)").and_return("y")
+			expect(machine).to receive(:state).and_return(state).twice
+			subject.call(env)
+
 		end
   	end
 
   	context "when machine is :paused, :saved or :poweroff" do
 		it "should prompt the user if they would like to force destroy the machine" do
+			state = double("state", id: :poweroff)
+			provisioner = double("provisioner")
+			subject.provisioner = provisioner
 
+      		expect(ui).to receive(:say).with(:warn, "Machine is currently not running. To properly leave the #{domain} network the machine needs to be running and connected to the network in which it was provisioned. Please run `vagrant up` and then `vagrant destroy`.\n")
+      		expect(ui).to receive(:ask).with("Would you like to continue destroying this machine, leaving this machine orphaned in the '#{domain}' network? (y/n)").and_return("y")
+      		expect(ui).to receive(:say).with(:warn, "Force destroying this machine and not leaving the domain foo.com. May FSM have mercy on your soul.")
+			expect(machine).to receive(:state).and_return(state).twice
+			expect(app).to receive(:call).with(env)
+			# Can't call destroy on a non-running machine
+			expect(provisioner).to_not receive(:destroy)
+
+			subject.call(env)
+
+			expect(env[:force_confirm_destroy]).to be(true)
 		end
 
 		it "should not pass on to middleware if user declines force destroy" do
+			state = double("state", id: :poweroff)
+			provisioner = double("provisioner")
+			subject.provisioner = provisioner
+
+      		expect(ui).to receive(:say).with(:warn, "Machine is currently not running. To properly leave the #{domain} network the machine needs to be running and connected to the network in which it was provisioned. Please run `vagrant up` and then `vagrant destroy`.\n")
+      		expect(ui).to receive(:ask).with("Would you like to continue destroying this machine, leaving this machine orphaned in the '#{domain}' network? (y/n)").and_return("n")
+			expect(machine).to receive(:state).and_return(state).twice
+			expect(app).to_not receive(:call).with(env)
+			expect(provisioner).to_not receive(:destroy)
+			expect(env[:force_confirm_destroy]).to be(nil)
+
+			subject.call(env)
 
 		end
   	end
 
   	context "when machine is :not_created" do
-  		it "should do nothing" do
+  		it "should pass control to the next middleware action" do
+			state = double("state", id: :not_created)
+			expect(machine).to receive(:state).and_return(state)
+
+			expect(app).to receive(:call).with(env)
+			subject.call(env)
 
   		end
   	end

--- a/spec/provisioner/leave_domain_spec.rb
+++ b/spec/provisioner/leave_domain_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+require 'vagrant-windows-domain/provisioner'
+require 'vagrant-windows-domain/action/leave_domain'
+require 'vagrant-windows-domain/config'
+require 'base'
+
+describe VagrantPlugins::WindowsDomain::LeaveDomain do
+
+  include_context "unit"
+  let(:instance) { described_class.new }
+
+  let(:root_path)           { (Pathname.new(Dir.mktmpdir)).to_s }
+  let(:ui)                  { Vagrant::UI::Silent.new }
+  let(:app)                 { double("app") }
+  let(:communicator)        { double ("communicator") }
+  let(:shell)               { double ("shell") }
+  let(:powershell)          { double ("powershell") }
+  let(:guest)               { double ("guest") }
+  let(:configuration_file)  { "manifests/MyWebsite.ps1" }
+  let(:module_path)         { ["foo/modules", "foo/modules2"] }
+  let(:config)         		{ VagrantPlugins::WindowsDomain::Config.new }
+  let(:vm)                  { double("vm", provisioners: [double("prov", config: config)]) }
+  let(:root_config)        	{ double("root_config", vm: vm) } 
+  let(:env)                 { {:ui => ui, :machine => machine} }
+  let(:machine)             { double("machine", ui: ui, id: "1234", config: root_config) }
+  subject                   { described_class.new app, env }
+
+  describe "call" do
+
+    before do
+      env = double("environment", root_path: "/tmp/vagrant-windows-domain-path", machine: machine)
+      allow(machine).to receive(:communicate).and_return(communicator)
+      allow(env).to receive(:machine).and_return(machine)
+      allow(communicator).to receive(:shell).and_return(shell)
+      allow(shell).to receive(:powershell).and_yield(:stdout, "myoldcomputername")
+    end
+
+    context "when no configuration exists for the machine" do
+		it "should pass control to the next middleware Action" do
+
+		end
+    end
+
+  	context "when machine is running" do
+		it "should prompt the user if they would like to destroy & d/c the machine" do
+		end
+  	end
+
+  	context "when machine is :paused, :saved or :poweroff" do
+		it "should prompt the user if they would like to force destroy the machine" do
+
+		end
+
+		it "should not pass on to middleware if user declines force destroy" do
+
+		end
+  	end
+
+  	context "when machine is :not_created" do
+  		it "should do nothing" do
+
+  		end
+  	end
+  end
+
+
+  describe "initialize" do
+
+    its("env")            	{ should eq(env) }
+    its("app")     			{ should eq(app) }
+    its("config")          	{ should eq(config) }
+    its("machine")          { should eq(machine) }
+
+  end
+
+end

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -73,7 +73,7 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
     it "should join the domain" do
       allow(communicator).to receive(:upload)
       allow(ui).to receive(:info)
-      expect(communicator).to receive(:sudo).with(". 'c:/tmp/vagrant-windows-domain-runner.ps1'", {:elevated=>true, :error_key=>:ssh_bad_exit_status_muted, :good_exit=>0, :shell=>:powershell}).and_return(0)
+      allow(shell).to receive(:powershell).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1")
       expect(communicator).to receive(:sudo).with("del c:/tmp/vagrant-windows-domain-runner.ps1")
       expect(machine).to receive(:action). with(:reload, {:provision_ignore_sentinel=>false})
       expect(communicator).to receive(:ready?).and_return(true)
@@ -85,7 +85,7 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
     it "should restart the machine on a successful domain join" do
       allow(communicator).to receive(:upload)
       allow(ui).to receive(:info)
-      expect(communicator).to receive(:sudo).with(". 'c:/tmp/vagrant-windows-domain-runner.ps1'", {:elevated=>true, :error_key=>:ssh_bad_exit_status_muted, :good_exit=>0, :shell=>:powershell}).and_return(0)
+      expect(shell).to receive(:powershell).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1")
       expect(communicator).to receive(:sudo).with("del c:/tmp/vagrant-windows-domain-runner.ps1")
       expect(machine).to receive(:action). with(:reload, {:provision_ignore_sentinel=>false})
       expect(communicator).to receive(:ready?).and_return(true)
@@ -95,8 +95,9 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
 
     it "should not restart the machine on a failed domain join attempt" do
       allow(communicator).to receive(:upload)
-      allow(ui).to receive(:info)
-      expect(communicator).to receive(:sudo).with(". 'c:/tmp/vagrant-windows-domain-runner.ps1'", {:elevated=>true, :error_key=>:ssh_bad_exit_status_muted, :good_exit=>0, :shell=>:powershell}).and_return(false)
+      allow(ui).to receive(:info).with("some exception thrown!", {:color=>:red, :new_line=>false, :prefix=>false}) # Red output on error please!
+      allow(ui).to receive(:info).with("\"Running Windows Domain Provisioner\"")
+      expect(shell).to receive(:powershell).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1").and_yield(:stderr, "some exception thrown!")
       expect(communicator).to receive(:sudo).with("del c:/tmp/vagrant-windows-domain-runner.ps1")
       expect(machine).to_not receive(:action). with(:reload, {:provision_ignore_sentinel=>false})
       subject.restart_sleep_duration = 0
@@ -166,8 +167,9 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
     it "should leave domain" do
       allow(machine).to receive(:communicate).and_return(communicator)
       expect(communicator).to receive(:upload)
-      expect(communicator).to receive(:sudo).with(". 'c:/tmp/vagrant-windows-domain-runner.ps1'", {:elevated=>true, :error_key=>:ssh_bad_exit_status_muted, :good_exit=>0, :shell=>:powershell}).and_return(0)
-      expect(ui).to receive(:info).with(any_args).once
+      expect(shell).to receive(:powershell).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1").and_yield(:stdout, "deleted")
+      expect(ui).to receive(:info).with("\"Running Windows Domain Provisioner\"")
+      expect(ui).to receive(:info).with("deleted", {:color=>:green, :new_line=>false, :prefix=>false})
       
       result = subject.leave_domain
       expect(result).to eq(true)
@@ -176,8 +178,9 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
     it "should leave domain when a `vagrant destroy` is issued" do
       allow(machine).to receive(:communicate).and_return(communicator)
       expect(communicator).to receive(:upload)
-      expect(communicator).to receive(:sudo).with(". 'c:/tmp/vagrant-windows-domain-runner.ps1'", {:elevated=>true, :error_key=>:ssh_bad_exit_status_muted, :good_exit=>0, :shell=>:powershell})
-      expect(ui).to receive(:info).with(any_args).once
+      expect(shell).to receive(:powershell).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1").and_yield(:stdout, "deleted")
+      expect(ui).to receive(:info).with("\"Running Windows Domain Provisioner\"")
+      expect(ui).to receive(:info).with("deleted", {:color=>:green, :new_line=>false, :prefix=>false})
 
       expect(ui).to_not receive(:say)
       expect(ui).to_not receive(:ask)
@@ -199,7 +202,7 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
       allow(machine).to receive(:communicate).and_return(communicator)
       allow(machine).to receive(:env).and_return(env)
       expect(communicator).to receive(:upload)
-      expect(communicator).to receive(:sudo).with(". 'c:/tmp/vagrant-windows-domain-runner.ps1'", {:elevated=>true, :error_key=>:ssh_bad_exit_status_muted, :good_exit=>0, :shell=>:powershell}).and_yield(:stdout, "deleted!")
+      expect(shell).to receive(:powershell).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1").and_yield(:stdout, "deleted")
       expect(ui).to receive(:info).with(any_args).twice
       expect(ui).to receive(:ask).with("Please enter your domain password (output will be hidden): ", {:echo=>false}).and_return("myusername")
       expect(ui).to receive(:ask).with("Please enter your domain username: ")      

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -73,7 +73,7 @@ describe VagrantPlugins::WindowsDomain::Provisioner do
     it "should join the domain" do
       allow(communicator).to receive(:upload)
       allow(ui).to receive(:info)
-      allow(shell).to receive(:powershell).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1")
+      expect(shell).to receive(:powershell).with("powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:/tmp/vagrant-windows-domain-runner.ps1")
       expect(communicator).to receive(:sudo).with("del c:/tmp/vagrant-windows-domain-runner.ps1")
       expect(machine).to receive(:action). with(:reload, {:provision_ignore_sentinel=>false})
       expect(communicator).to receive(:ready?).and_return(true)


### PR DESCRIPTION
This PR includes bug fixes and enhancements #2, #4, #5, #6 

In short, it 

* Provides better output handling (via a hack-ish slurp of the WinRM response and determining if there is an error via the presence or lack-thereof of `:stderr` responses).
* Has much improved behaviour around machine states within and across machines (e.g. It has sensible behaviour if trying to destroy a halted machine, and won't fire if a machine lacks a windows_domain configuration)
