### PR TITLE
Split to remove

### DIFF
--- a/lib/vagrant-windows-domain/config.rb
+++ b/lib/vagrant-windows-domain/config.rb
@@ -45,6 +45,9 @@ module VagrantPlugins
       # When this option is used username/password are not required
       attr_accessor :unsecure
 
+      # The trigger whether plugin should rename the computer or omit the renaming
+      attr_accessor :rename_trigger
+
       def initialize
         super
         @domain            = UNSET_VALUE
@@ -54,6 +57,7 @@ module VagrantPlugins
         @join_options      = {}
         @ou_path           = UNSET_VALUE
         @unsecure          = UNSET_VALUE
+        @rename_trigger    = UNSET_VALUE
         @logger            = Log4r::Logger.new("vagrant::vagrant_windows_domain")
       end
 
@@ -72,6 +76,7 @@ module VagrantPlugins
         @join_options      = [] if @join_options == UNSET_VALUE
         @ou_path           = nil if @ou_path == UNSET_VALUE
         @unsecure          = false if @unsecure == UNSET_VALUE
+        @rename_trigger    = false if @rename_trigger == UNSET_VALUE
       end
 
       # Validate configuration and return a hash of errors.

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -149,6 +149,10 @@ module VagrantPlugins
       def generate_command_runner_script(add_to_domain=true)
         path = File.expand_path("../templates/runner.ps1", __FILE__)
 
+        if @config.computer_name != nil && @old_computer_name != nil && @config.computer_name.casecmp(@old_computer_name) != 0
+          @config.rename_trigger = true
+        end
+        
         Vagrant::Util::TemplateRenderer.render(path, options: {
             config: @config,
             username: @config.username,
@@ -156,10 +160,23 @@ module VagrantPlugins
             domain: @config.domain,
             add_to_domain: add_to_domain,
             unsecure: @config.unsecure,
+            rename_trigger: @config.rename_trigger,
             parameters: generate_command_arguments(add_to_domain)
+        }, options_rename: {
+            parameters: generate_command_arguments_rename
         })
       end
 
+      # Generates the argument list for rename 
+      def generate_command_arguments_rename
+
+        params = {"-NewName" => @config.computer_name}
+        params["-DomainCredential $credentials"] = nil
+        join_params = @config.join_options.map { |a| "#{a}" }.join(',')
+        params.map { |k,v| "#{k}" + (!v.nil? ? " #{v}": '') }.join(' ') + join_params
+        
+      end
+      
       # Generates the argument list
       def generate_command_arguments(add_to_domain=true)
 

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -4,6 +4,9 @@ $credentials = New-Object System.Management.Automation.PSCredential ("<%= option
 <% end %>
 <% if options[:add_to_domain] === true %>
 Add-Computer <%= options[:parameters] %> -Verbose -Force
+<% if options[:rename_trigger] === true %>
+Rename-Computer <%= options_rename[:parameters] %> -Verbose -Force
+<% end %>
 <% else %>
 Remove-Computer <%= options[:parameters] %> -Workgroup "WORKGROUP" -Verbose -Force
 <% end %>

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -5,7 +5,22 @@ $credentials = New-Object System.Management.Automation.PSCredential ("<%= option
 <% if options[:add_to_domain] === true %>
 Add-Computer <%= options[:parameters] %> -Verbose -Force
 <% if options[:rename_trigger] === true %>
-Rename-Computer <%= options_rename[:parameters] %> -Verbose -Force
+$completed = $false
+while ( -not $completed) {
+try {
+Rename-Computer <%= options_rename[:parameters] %> -Verbose -Force -ErrorAction Stop
+$completed = $true
+} catch {
+if ($retrycount -ge 5) {
+Write-Verbose ("Rename failed the maximum number of {1} times." -f $retrycount)
+throw
+} else {
+Write-Verbose ("Rename failed, Retrying in 5 seconds...")
+Start-sleep -s 5
+$retrycount++
+}
+}
+}
 <% end %>
 <% else %>
 Remove-Computer <%= options[:parameters] %> -Workgroup "WORKGROUP" -Verbose -Force

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -7,19 +7,19 @@ Add-Computer <%= options[:parameters] %> -Verbose -Force
 <% if options[:rename_trigger] === true %>
 $completed = $false
 while ( -not $completed) {
-try {
-Rename-Computer <%= options_rename[:parameters] %> -Verbose -Force -ErrorAction Stop
-$completed = $true
-} catch {
-if ($retrycount -ge 5) {
-Write-Verbose ("Rename failed the maximum number of {1} times." -f $retrycount)
-throw
-} else {
-Write-Verbose ("Rename failed, Retrying in 5 seconds...")
-Start-sleep -s 5
-$retrycount++
-}
-}
+	try {
+		Rename-Computer <%= options_rename[:parameters] %> -Verbose -Force -ErrorAction Stop
+		$completed = $true
+	} catch {
+		if ($retrycount -ge 5) {
+			Write-Host ("Rename failed the maximum number of $retrycount times.")
+			throw
+		} else {
+			Write-Host ("Rename failed, Retrying in 5 seconds...")
+			Start-sleep -s 5
+			$retrycount++
+		}
+	}
 }
 <% end %>
 <% else %>


### PR DESCRIPTION
Hi, this pull request is intended to fix the [following issue](https://github.com/SEEK-Jobs/vagrant-windows-domain/issues/11) and also add more stability to the plugin when renaming the computer. 
The update splits _Add-Computer_ into two stages _Add-Computer_ and _Rename-Computer_, Our experience showed that on Rename the plugin would occasionally timeout and Vagrant continues working with the computer added to the domain under the old name. Thus we implemented five re-tries of rename command until it fails. 
We already have an evidence of this code change working, occasionally we have one re-try in the Vagrant log during host rename.
@mefellows, could you please review this code. Thanks in advance.