### PR TITLE
Allow force flag to skip confirmation dialog for automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 before_install:
 - rvm @global do gem uninstall bundler --all --executables
 - gem uninstall bundler --all --executables
-- gem install bundler --version '< 1.7.0'
+- gem install bundler --version '< 1.10.7'
 rvm:
 - 2.0.0
 - 2.1.0
@@ -13,7 +13,7 @@ matrix:
   fast_finish: true
 env:
   matrix:
-  - VAGRANT_VERSION=v1.6.5
+  - VAGRANT_VERSION=v1.8.0
   global:
     secure: bs4ezY+1Wksy8hH3nymPJ3AL99mpXULVc/AIh16JetEYw1850QkX7r4gQukMlcyByKUhxucjDLid0Y+KDH5kGMM16QjrVQGhAnUQzMoLD2qPbAaxDCUqpCJtFEEQKYxJvFvEK8a5SQzAsTVG4sgABQ/MllsIIH0FjkWgFtH6050=
 script: bundle exec rake test:unit

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -1,4 +1,4 @@
-require "log4r"
+require 'log4r'
 require 'erb'
 
 module VagrantPlugins
@@ -188,8 +188,11 @@ module VagrantPlugins
 
         # Remove with unsecure
         join_params = @config.join_options.map { |a| "#{a}" }.join(',')
-        params.map { |k,v| "#{k}" + (!v.nil? ? " #{v}": '') }.join(' ') + join_params
-        
+        if join_params.to_s != ''
+          params["-Options"] = join_params
+        end
+
+        params.map { |k,v| "#{k}" + (!v.nil? ? " #{v}": '') }.join(' ')
       end
 
       # Writes the PowerShell runner script to a location on the guest.

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -136,7 +136,7 @@ module VagrantPlugins
           @logger.info("==> Requesting username as none provided")
           config.username = @machine.env.ui.ask("Please enter your domain username: ")
         else
-          @logger.info("==> Using username: #{config.username}")
+          @logger.info("==> Using domain username: #{config.username}")
         end
 
         if (config.password == nil)
@@ -152,8 +152,8 @@ module VagrantPlugins
       # to be cleaned up.
       def destroy
         if @config && @config.domain != nil
-          set_credentials
           if is_joined_to_domain()
+            set_credentials
             result = leave_domain
             if result
               @logger.debug("Need to reboot to leave the domain correctly")

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -172,8 +172,9 @@ module VagrantPlugins
         options[:provision_ignore_sentinel] = false
         options[:lock] = false
         @machine.action(:reload, options)
-        sleep(5)
-        @machine.communicate.wait_for_ready(@machine.config.vm.boot_timeout)
+        begin
+          sleep 5
+        end until @machine.communicate.ready?
       end
 
       # Verify that we can call the remote operations.

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -172,9 +172,12 @@ module VagrantPlugins
         options[:provision_ignore_sentinel] = false
         options[:lock] = false
         @machine.action(:reload, options)
-        begin
-          sleep 5
-        end until @machine.communicate.ready?
+
+        Timeout.timeout(@machine.config.vm.boot_timeout) do
+          begin
+            sleep 5
+          end until @machine.communicate.ready?
+        end
       end
 
       # Verify that we can call the remote operations.

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -150,9 +150,8 @@ module VagrantPlugins
       # to be cleaned up.
       def destroy
         if @config && @config.domain != nil
-
+          set_credentials
           if is_joined_to_domain()
-            set_credentials
             result = leave_domain
             if result
               @logger.debug("Need to reboot to leave the domain correctly")

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -172,6 +172,7 @@ module VagrantPlugins
         options[:provision_ignore_sentinel] = false
         options[:lock] = false
         @machine.action(:reload, options)
+        sleep(5)
         @machine.communicate.wait_for_ready(@machine.config.vm.boot_timeout)
       end
 

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -172,9 +172,7 @@ module VagrantPlugins
         options[:provision_ignore_sentinel] = false
         options[:lock] = false
         @machine.action(:reload, options)
-        begin
-          sleep @restart_sleep_duration
-        end until @machine.communicate.ready?
+        @machine.communicate.wait_for_ready(@machine.config.vm.boot_timeout)
       end
 
       # Verify that we can call the remote operations.

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -170,6 +170,7 @@ module VagrantPlugins
         @machine.env.ui.say(:info, "Restarting computer for updates to take effect.")
         options = {}
         options[:provision_ignore_sentinel] = false
+        options[:lock] = false
         @machine.action(:reload, options)
         begin
           sleep @restart_sleep_duration

--- a/lib/vagrant-windows-domain/provisioner.rb
+++ b/lib/vagrant-windows-domain/provisioner.rb
@@ -135,6 +135,8 @@ module VagrantPlugins
         if (config.username == nil)
           @logger.info("==> Requesting username as none provided")
           config.username = @machine.env.ui.ask("Please enter your domain username: ")
+        else
+          @logger.info("==> Using username: #{config.username}")
         end
 
         if (config.password == nil)

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -38,7 +38,7 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 	&shutdown /a
 
 	# Force shutdown the machine now
-	&shutdown /s /t 1 /c "Vagrant Halt" /f /d p:4:1	
+	&shutdown /s /t 15 /c "Vagrant Halt" /f /d p:4:1	
 }
 <% else %>
 if (!(Test-JoinedToADomain)) {
@@ -52,6 +52,6 @@ if (!(Test-JoinedToADomain)) {
 	&shutdown /a
 
 	# Force shutdown the machine now
-	&shutdown /s /t 1 /c "Vagrant Halt" /f /d p:4:1
+	&shutdown /s /t 15 /c "Vagrant Halt" /f /d p:4:1
 }
 <% end %>

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -32,6 +32,13 @@ if (Test-PartOfDomain -computerName $computerName -domain $domain){
 } else {
 	Add-Computer <%= options[:parameters] %> -Verbose -Force -PassThru
 	Repair-OpenSSHPasswd
+
+	# Fix vagrant-windows GH-129, if there's an existing scheduled
+	# reboot cancel it so shutdown succeeds
+	&shutdown /a
+
+	# Force shutdown the machine now
+	&shutdown /s /t 1 /c "Vagrant Halt" /f /d p:4:1	
 }
 <% else %>
 if (!(Test-JoinedToADomain)) {
@@ -39,5 +46,12 @@ if (!(Test-JoinedToADomain)) {
 } else {
 	Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
 	Repair-OpenSSHPasswd
+
+	# Fix vagrant-windows GH-129, if there's an existing scheduled
+	# reboot cancel it so shutdown succeeds
+	&shutdown /a
+
+	# Force shutdown the machine now
+	&shutdown /s /t 1 /c "Vagrant Halt" /f /d p:4:1
 }
 <% end %>

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -1,9 +1,9 @@
 <% if options[:username] != nil && options[:unsecure] != true %>
-$secpasswd = ConvertTo-SecureString "<%= options[:password] %>" -AsPlainText -Force
-$credentials = New-Object System.Management.Automation.PSCredential ("<%= options[:username] %>", $secpasswd)
+$secpasswd = ConvertTo-SecureString '<%= options[:password] %>' -AsPlainText -Force
+$credentials = New-Object System.Management.Automation.PSCredential ('<%= options[:username] %>', $secpasswd)
 <% end %>
 <% if options[:add_to_domain] === true %>
-Add-Computer <%= options[:parameters] %> -Verbose -Force
+Add-Computer <%= options[:parameters] %> -Verbose -Force -PassThru
 <% else %>
-Remove-Computer <%= options[:parameters] %> -Workgroup "WORKGROUP" -Verbose -Force
+Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
 <% end %>

--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -1,9 +1,43 @@
+function Test-PartOfDomain($computerName, $domain){
+	$computerSystem = gwmi win32_computersystem
+	return ($computerSystem.Name -eq $computerName) -and ($computerSystem.PartOfDomain) -and ($computerSystem.Domain -eq $domain) 
+}
+
+function Test-JoinedToADomain(){
+	$computerSystem = gwmi win32_computersystem
+	return $computerSystem.PartOfDomain
+}
+
+function Repair-OpenSSHPasswd(){
+	$passwdPath = 'C:\Program Files\OpenSSH\etc\passwd'
+	$mkpasswdPath = 'C:\Program Files\OpenSSH\bin\mkpasswd.exe'
+	if ((Test-Path $passwdPath) -and (Test-Path $mkpasswdPath)){
+		$passwd = &$mkpasswdPath
+		$passwd = $passwd -replace '^([^+]*\+)', ''
+		$passwd | Set-Content $passwdPath -Encoding Ascii
+	}
+}
+
+$computerName='<%= options[:computer_name] %>'
 <% if options[:username] != nil && options[:unsecure] != true %>
-$secpasswd = ConvertTo-SecureString '<%= options[:password] %>' -AsPlainText -Force
-$credentials = New-Object System.Management.Automation.PSCredential ('<%= options[:username] %>', $secpasswd)
+$domain='<%= options[:domain] %>'
+$username='<%= options[:username] %>'
+$password='<%= options[:password] %>'
+$secpasswd = ConvertTo-SecureString $password -AsPlainText -Force
+$credentials = New-Object System.Management.Automation.PSCredential ($username, $secpasswd)
 <% end %>
 <% if options[:add_to_domain] === true %>
-Add-Computer <%= options[:parameters] %> -Verbose -Force -PassThru
+if (Test-PartOfDomain -computerName $computerName -domain $domain){
+	throw "$computerName already part of domain $domain"
+} else {
+	Add-Computer <%= options[:parameters] %> -Verbose -Force -PassThru
+	Repair-OpenSSHPasswd
+}
 <% else %>
-Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
+if (!(Test-JoinedToADomain)) {
+	Throw "$computerName not part of any domain"
+} else {
+	Remove-Computer <%= options[:parameters] %> -Workgroup 'WORKGROUP' -Verbose -Force -PassThru
+	Repair-OpenSSHPasswd
+}
 <% end %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'vagrant-windows-domain/plugin'
 require 'rspec/its'
 require 'base'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
 ]
@@ -18,7 +18,7 @@ end
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
-    c.syntax = :expect
+    c.syntax = [:should, :expect]
   end
   config.color = true
   config.tty = true

--- a/vagrant-windows-domain.gemspec
+++ b/vagrant-windows-domain.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake", '~> 10.3', '>= 10.3.0'
-  spec.add_development_dependency "bundler", "~> 1.6", '>= 1.6.0'
-  spec.add_development_dependency "coveralls", "~> 0.7.1", '>= 0.7.1'
-  spec.add_development_dependency "rspec-core", '~> 3.1', '>= 3.1.0'
-  spec.add_development_dependency "rspec-expectations", '~> 3.1', '>= 3.1.0'
-  spec.add_development_dependency "rspec-mocks", '~> 3.1', '>= 3.1.0'
-  spec.add_development_dependency "rspec-its", "~> 1.0.1", '>= 1.0.0'
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "bundler", ">= 1.5.2", "<= 1.10.6"
+  spec.add_development_dependency "coveralls", "~> 0.8.10", '>= 0.8.10'
+  spec.add_development_dependency "rspec-core", '~> 3.4.2', '>= 3.4.2'
+  spec.add_development_dependency "rspec-expectations", '~> 3.4.0', '>= 3.4.0'
+  spec.add_development_dependency "rspec-mocks", '~> 3.4.1', '>= 3.4.1'
+  spec.add_development_dependency "rspec-its", "~> 1.2.0", '>= 1.2.0'
 end

--- a/vagrant-windows-domain.gemspec
+++ b/vagrant-windows-domain.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "bundler", ">= 1.5.2", "<= 1.10.6"
+  spec.add_development_dependency "bundler", ">= 1.5.2", "<= 1.12.5"
   spec.add_development_dependency "coveralls", "~> 0.8.10", '>= 0.8.10'
   spec.add_development_dependency "rspec-core", '~> 3.4.2', '>= 3.4.2'
   spec.add_development_dependency "rspec-expectations", '~> 3.4.0', '>= 3.4.0'


### PR DESCRIPTION
- For automation there needs to be a way to not be forced to specify user input. It will now skip the user prompt if --force flag is passed in
- Performance improvement by only rebooting machines that are not already joined
- When joining a domain, if openssh is used then the username will need to be modified (this is a pretty common thing)