### PR TITLE
Work around an issue where the machine does not restart when destroyed.

### DIFF
--- a/lib/vagrant-windows-domain/templates/runner.ps1.erb
+++ b/lib/vagrant-windows-domain/templates/runner.ps1.erb
@@ -73,6 +73,6 @@ if (!(Test-JoinedToADomain)) {
 	&shutdown /a
 
 	# Force shutdown the machine now
-	&shutdown /s /t 15 /c "Vagrant Halt" /f /d p:4:1
+	&shutdown /r /t 15 /c "Vagrant Halt" /f /d p:4:1
 }
 <% end %>


### PR DESCRIPTION
when a vagrant destroy is ran it does the work, unjoins the domain, and
when the reload is issued the machine goes down and does not come backup
and leaves me hanging with
Restarting computer for updates to take effect.
==> default: Attempting graceful shutdown of VM...

C:/HashiCorp/Vagrant/embedded/gems/gems/httpclient-2.8.2.4/lib/httpclient/session.rb:604:in
`initialize': No connection could be made because the target machine
actively refused it. - connect(2) for "127.0.0.1" port 55985
(127.0.0.1:55985) (Errno::ECONNREFUSED)

By doing shutdown /r ... instead of shutdown /s ... this causes it to
actually reboot instead of halt and get destroyed.